### PR TITLE
Use references field

### DIFF
--- a/man/ccm.Rd
+++ b/man/ccm.Rd
@@ -48,18 +48,6 @@ The metrics include:
 - dVelocity (dVe): Distance-based climate change velocity (based on the method used in Garcia et al. (2014))
 
 - gVelocity (gVe): Gradiant-based climate change velocity (based on the method represented in Burrow et al. (2011))
-
-
-References:
-
-- Burrows MT, Schoeman DS, Buckley LB, Moore P, Poloczanska ES, Brander KM, Brown C, Bruno JF, Duarte CM, Halpern BS, Holding J. (2011) The pace of shifting climate in marine and terrestrial ecosystems. Science. Nov 4;334(6056):652-5.
-
-- Garcia, R.A., Cabeza, M., Rahbek, C. and Araújo, M.B. (2014). Multiple dimensions of climate change and their implications for biodiversity. Science, 344(6183).
-
-- Hamann, A., Roberts, D.R., Barber, Q.E., Carroll, C. and Nielsen, S.E. (2015). Velocity of climate change algorithms for guiding conservation and management. Global Change Biology, 21(2), pp.997-1004.
-
-
-
 }
 
 
@@ -75,6 +63,13 @@ A Raster object (RasterLayer or RasterStackBrick or SpatRaster depending on the 
 \url{https://r-gis.net/}
 }
 
+\references{
+- Burrows MT, Schoeman DS, Buckley LB, Moore P, Poloczanska ES, Brander KM, Brown C, Bruno JF, Duarte CM, Halpern BS, Holding J. (2011) The pace of shifting climate in marine and terrestrial ecosystems. Science. Nov 4;334(6056):652-5.
+
+- Garcia, R.A., Cabeza, M., Rahbek, C. and Araújo, M.B. (2014). Multiple dimensions of climate change and their implications for biodiversity. Science, 344(6183).
+
+- Hamann, A., Roberts, D.R., Barber, Q.E., Carroll, C. and Nielsen, S.E. (2015). Velocity of climate change algorithms for guiding conservation and management. Global Change Biology, 21(2), pp.997-1004.
+}
 
 \examples{
 \donttest{

--- a/man/dVelocity.Rd
+++ b/man/dVelocity.Rd
@@ -24,8 +24,6 @@
 \description{
 The method is developed based on the approach used in Garcia et al. (2014)
 Gradiant-based velocity is also implemented in the package and is available through the \code{gVelocity} function.
-
-Garcia, R.A., Cabeza, M., Rahbek, C. and Araújo, M.B. (2014). Multiple dimensions of climate change and their implications for biodiversity. Science, 344(6183).
 }
 
 \value{
@@ -39,6 +37,9 @@ A single Raster layer (RasterLayer or SpatRaster depending on the input)
 
 }
 
+\references{
+Garcia, R.A., Cabeza, M., Rahbek, C. and Araújo, M.B. (2014). Multiple dimensions of climate change and their implications for biodiversity. Science, 344(6183).
+}
 
 \examples{
 

--- a/man/gVelocity.Rd
+++ b/man/gVelocity.Rd
@@ -22,8 +22,6 @@
 The method is developed based on Burrow et al. (2011) which is a gradient-based velocity of climate change. Climate velocity can inform conservation planning and action in a warming world.
 
 Distance-based velocity is also implemented in the package and is available through the ccm function.
-
-Burrows MT, Schoeman DS, Buckley LB, Moore P, Poloczanska ES, Brander KM, Brown C, Bruno JF, Duarte CM, Halpern BS, Holding J. The pace of shifting climate in marine and terrestrial ecosystems. Science. 2011 Nov 4;334(6056):652-5..
 }
 
 \value{
@@ -35,6 +33,10 @@ A single Raster layer (RasterLayer or SpatRaster depending on the input)
 
 \email{taheri.shi@gmail.com}; \email{naimi.b@gmail.com}
 
+}
+
+\references{
+Burrows MT, Schoeman DS, Buckley LB, Moore P, Poloczanska ES, Brander KM, Brown C, Bruno JF, Duarte CM, Halpern BS, Holding J. The pace of shifting climate in marine and terrestrial ecosystems. Science. 2011 Nov 4;334(6056):652-5.
 }
 
 \examples{

--- a/man/velocity.Rd
+++ b/man/velocity.Rd
@@ -23,10 +23,6 @@
 
 \description{
 The method is developed based on the method represented in the paper Hamnan et al. (2015). Two additional functions including Distance-based (\code{dVelocity}) and Gradiant-based velocity  (\code{gVelocity}) are also implemented and available in the package.
-
-- Hamann, A., Roberts, D.R., Barber, Q.E., Carroll, C. and Nielsen, S.E. (2015). Velocity of climate change algorithms for guiding conservation and management. Global Change Biology, 21(2), pp.997-1004.
-
-
 }
 
 \value{
@@ -40,6 +36,9 @@ A single Raster layer (RasterLayer or SpatRaster depending on the input)
 
 }
 
+\references{
+- Hamann, A., Roberts, D.R., Barber, Q.E., Carroll, C. and Nielsen, S.E. (2015). Velocity of climate change algorithms for guiding conservation and management. Global Change Biology, 21(2), pp.997-1004.
+}
 
 \examples{
 


### PR DESCRIPTION
Hi, 

Instead of adding references as text in details, they can be added with `\references{...}` field in the man files. Moreover I corrected a minor typo at the reference of gVelocity.

Thanks.